### PR TITLE
Secure Fetching via Nuxt Server API

### DIFF
--- a/nuxt-app/nuxt.config.ts
+++ b/nuxt-app/nuxt.config.ts
@@ -2,10 +2,12 @@
 export default defineNuxtConfig({
     modules: ["@nuxt/ui", "@nuxtjs/strapi"],
     css: ["~/assets/main.css"],
-    strapi: {
-        url: process.env.STRAPI_API_BASE_URL,
-        prefix: "/api",
-    },
     compatibilityDate: "2024-11-01",
     devtools: { enabled: true },
+    runtimeConfig: {
+        apiToken: "",
+        public: {
+            apiBase: process.env.STRAPI_API_BASE_URL,
+        },
+    },
 });

--- a/nuxt-app/pages/[slug].vue
+++ b/nuxt-app/pages/[slug].vue
@@ -2,18 +2,11 @@
 import { useEmbedParser } from "@/composables/useEmbedParser";
 
 const route = useRoute();
-const { find } = useStrapi();
 
-const { data: result } = await useAsyncData("article", () =>
-    find("articles", {
-        populate: ["cover"],
-        filters: {
-            slug: { $eq: route.params.slug },
-        },
-    })
+const { data: article, error } = await useFetch(
+    `/api/articles/${route.params.slug}`
 );
 
-const article = computed(() => result.value?.data?.[0]);
 const rawHtml = article.value?.body;
 const parsedHtml = useEmbedParser(rawHtml);
 

--- a/nuxt-app/pages/index.vue
+++ b/nuxt-app/pages/index.vue
@@ -1,12 +1,6 @@
 <script setup lang="ts">
-const { find } = useStrapi();
-
-const { data: articles, error } = await useAsyncData("articles", () =>
-    find("articles", {
-        populate: ["cover"],
-    })
-);
-
+const { data: articles, error } = await useFetch("/api/articles");
+console.log(articles.value);
 function formatDate(date: string) {
     return new Date(date).toLocaleDateString("en-US", {
         year: "numeric",

--- a/nuxt-app/server/api/articles/[slug].ts
+++ b/nuxt-app/server/api/articles/[slug].ts
@@ -1,0 +1,40 @@
+export default defineEventHandler(async (event) => {
+    const config = useRuntimeConfig();
+    const slug = getRouterParam(event, "slug");
+
+    if (!slug) {
+        throw createError({ statusCode: 400, message: "Missing slug" });
+    }
+
+    try {
+        const response = await $fetch(`${config.public.apiBase}/api/articles`, {
+            headers: {
+                Authorization: `Bearer ${config.apiToken}`,
+            },
+            query: {
+                "filters[slug][$eq]": slug,
+                populate: "cover",
+            },
+        });
+
+        const article = response?.data?.[0];
+
+        if (!article) {
+            throw createError({
+                statusCode: 404,
+                message: "Article not found",
+            });
+        }
+
+        return article;
+    } catch (err) {
+        console.error(
+            "Error fetching article:",
+            err.data || err.message || err
+        );
+        throw createError({
+            statusCode: 500,
+            message: "Internal Server Error",
+        });
+    }
+});

--- a/nuxt-app/server/api/articles/index.ts
+++ b/nuxt-app/server/api/articles/index.ts
@@ -1,0 +1,14 @@
+export default defineEventHandler(async () => {
+    const config = useRuntimeConfig();
+
+    const data = await $fetch(
+        `${config.public.apiBase}/api/articles?populate=cover`,
+        {
+            headers: {
+                Authorization: `Bearer ${config.apiToken}`,
+            },
+        }
+    );
+
+    return data;
+});


### PR DESCRIPTION
This PR implements a secure and production-ready way of fetching articles from Strapi using Nuxt server routes (/server/api). The goal is to avoid exposing the Strapi API token in the frontend bundle, which is especially important when deploying to platforms like Netlify, where secret scanning can block builds.

### Why this approach

- Protects the API token using useRuntimeConfig() (token never leaks to client)
- Avoids Netlify build failures caused by secrets found in public code
- Keeps a clean frontend that fetches from /api/articles and /api/articles/[slug]
- Enables future extensibility (custom filtering, sanitization, etc.)

###  What was added

- `server/api/articles/index.ts`: Fetches a list of articles with populate=cover
- `server/api/articles/[slug].ts`: Fetches a single article by slug using filters[slug][$eq]
- Uses `useRuntimeConfig()` to safely load the API token from .env
- Frontend pages now consume these endpoints using `useFetch()`
- Flattened data on the server to simplify usage in templates

